### PR TITLE
Move to 3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bioconductor/bioconductor_docker:devel
+FROM bioconductor/bioconductor_docker:3.19
 
 WORKDIR /home/rstudio
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM bioconductor/bioconductor_docker:3.19
+FROM bioconductor/bioconductor_docker:3.20
 
 WORKDIR /home/rstudio
 
 COPY --chown=rstudio:rstudio . /home/rstudio/
 
-RUN Rscript -e "options(repos = c(CRAN = 'https://cran.r-project.org')); BiocManager::install(ask=FALSE)"
-
-RUN Rscript -e "options(repos = c(CRAN = 'https://cran.r-project.org')); devtools::install('.', dependencies=TRUE, build_vignettes=TRUE, repos = BiocManager::repositories())"
+RUN ln -s /usr/lib/x86_64-linux-gnu/libtiff.so.6 /usr/lib/x86_64-linux-gnu/libtiff.so.5 && \
+    Rscript -e "options(repos = c(CRAN = 'https://cran.r-project.org')); BiocManager::install(ask=FALSE)" && \
+    Rscript -e "options(repos = c(CRAN = 'https://cran.r-project.org')); devtools::install('.', dependencies=TRUE, build_vignettes=TRUE, repos = BiocManager::repositories())"


### PR DESCRIPTION
3.20 is failing because of EBImage, xref https://github.com/Bioconductor/bioconductor_docker/issues/112. I will look into this tomorrow morning.
`devel` container is still not updated so will be an old 3.20, so not sure how that will act up since it's trying to use a release version as if it's devel (we just released 3.20 last week, and still having issues with R-devel 4.5.0 in arm64 so the devel containers for 3.21 aren't out yet).
I would suggest trying with `3.19` which in my last run https://github.com/almahmoud/scdneySpatial_BiocAsia2024/actions/runs/11712559485/job/32623511993#step:9:4122 is successfully installing the packages, and getting to the vignette, to then fail in the vignette with:
```
#10 320.7 Quitting from lines 375-380 [load-spe] (scdneySpatial.Rmd)
#10 320.7 Error: processing vignette 'scdneySpatial.Rmd' failed with diagnostics:
#10 320.7 'spe_Ferguson_2022' is not an exported object from 'namespace:SpatialDatasets'
#10 320.7 --- failed re-building ‘scdneySpatial.Rmd’
```

I see you've made more changes since, so maybe you already resolved this, but just wanted to share the info from what I had on my side in case helpful