### PR TITLE
Remove binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ WORKDIR /home/rstudio
 
 COPY --chown=rstudio:rstudio . /home/rstudio/
 
-RUN ln -s /usr/lib/x86_64-linux-gnu/libtiff.so.6 /usr/lib/x86_64-linux-gnu/libtiff.so.5 && \
+RUN export BIOCONDUCTOR_USE_CONTAINER_REPOSITORY=FALSE && \
     Rscript -e "options(repos = c(CRAN = 'https://cran.r-project.org')); BiocManager::install(ask=FALSE)" && \
     Rscript -e "options(repos = c(CRAN = 'https://cran.r-project.org')); devtools::install('.', dependencies=TRUE, build_vignettes=TRUE, repos = BiocManager::repositories())"


### PR DESCRIPTION
This is an actual fix, rather than the hacky linking before. I will temporarily change the running instance on the live Galaxy to the new image, so no worries to merge/rebuild before your workshop